### PR TITLE
feat: updated React dependency version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "typescript": "^4.0.3"
   },
   "peerDependencies": {
-    "react": ">=16.8.6"
+    "react": "^16.8.0 || ^17.0.0"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "typescript": "^4.0.3"
   },
   "peerDependencies": {
-    "react": "^16.8.6"
+    "react": ">=16.8.6"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
Proposing to allow also react17

Hello Eric, i would like to propose the change to allow your extension to be used also by react17 built projects. Your current limitation is currently a bit harsh and i would recommend allowing big versions ahead also.

Thanks